### PR TITLE
Update foreign key instead of related object

### DIFF
--- a/lib/DBIx/Class/ResultSet/RecursiveUpdate.pm
+++ b/lib/DBIx/Class/ResultSet/RecursiveUpdate.pm
@@ -370,10 +370,15 @@ sub _update_relation {
             elsif ( $info->{attrs}{accessor} eq 'single' &&
                 defined $object->$name )
             {
+                my $no_new_object = 0;
+                my @pks = $related_resultset->result_source->primary_columns;
+                if ( all { exists $updates->{$_} } @pks ) {
+                    $no_new_object = 1;
+                }
                 $sub_object = recursive_update(
                     resultset => $related_resultset,
                     updates   => $updates,
-                    object    => $object->$name
+                    $no_new_object ? () : (object => $object->$name),
                 );
             }
             else {
@@ -650,6 +655,16 @@ Clearing the relationship (only works if cols are nullable!):
     my $dvd = $dvd_rs->recursive_update( {
         id    => 1,
         owner => undef,
+    });
+
+Updating a relationship including its (full) primary key:
+
+    my $dvd = $dvd_rs->recursive_update( {
+        id    => 1,
+        owner => {
+            id   => 2,
+            name => "George",
+        },
     });
 
 =head2 Treatment of might_have relationships

--- a/t/belongs_to_including_pks.t
+++ b/t/belongs_to_including_pks.t
@@ -1,0 +1,41 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+use lib qw(t/lib);
+use DBICTest;
+
+my $schema = DBICTest->init_schema();
+
+diag
+    'Update foreign key with an updated primary key (similar to "Create foreign key col obj including PK" in 96multi_create.t)';
+eval {
+    my $new_cd_hashref = {
+        cdid   => 30,
+        title  => 'Boogie Woogie',
+        year   => '2007',
+        artist => { artistid => 1 }
+    };
+
+    my $cd = $schema->resultset("CD")->find(1);
+    is( $cd->artist->id, 1, 'rel okay' );
+
+    my $new_cd = $schema->resultset("CD")->recursive_update($new_cd_hashref);
+    is( $new_cd->artist->id, 1, 'new id retained okay' );
+};
+
+eval {
+    my $updated_cd = $schema->resultset("CD")->recursive_update(
+        {   cdid   => 30,
+            title  => 'Boogie Wiggle',
+            year   => '2007',
+            artist => { artistid => 2 }
+        }
+    );
+    is( $updated_cd->artist->id, 2, 'related artist changed correctly' );
+};
+is( $@, '', 'new cd created without clash on related artist' );
+
+done_testing;
+
+# vim: set ft=perl ts=4 expandtab:

--- a/t/lib/DBICTest/Schema/CD.pm
+++ b/t/lib/DBICTest/Schema/CD.pm
@@ -33,8 +33,10 @@ __PACKAGE__->add_columns(
 __PACKAGE__->set_primary_key('cdid');
 __PACKAGE__->add_unique_constraint([ qw/artist title/ ]);
 
-__PACKAGE__->belongs_to( artist => 'DBICTest::Schema::Artist', undef, { 
-    is_deferrable => 1, 
+__PACKAGE__->belongs_to( artist => 'DBICTest::Schema::Artist',
+    {artistid => "artist"}, {
+    is_deferrable => 1,
+    accessor => "single",
 });
 
 # in case this is a single-cd it promotes a track from another cd


### PR DESCRIPTION
Hey, i have changed _update_relation a bit so that on a belongs_to relationship (single), the existing related object is not touched when all PKs are set for that relation.

With that i can use the same datastructure for insert and update in a simple HTML::FormHandler::Model::DBIC form.
