### PR TITLE
Reformatted Changes file as per CPAN::Changes::Spec

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,69 +1,70 @@
-Revision history for DBIx::Class::ResultSet::RecursiveUpdate
+Revision history for Perl module DBIx::Class::ResultSet::RecursiveUpdate
 
-0.31 Wed Nov 6, 2013
+0.31 2013-11-06
     - Fixed failing test when DBIC_TRACE_PROFILE is set
     - Fix problem with join_type LEFT and undef (rt67528)
     - discard_changes before handling post_updates
 
-0.30  Fri Jun 7, 2013
+0.30 2013-06-07
     - Update foreign key instead of related object when all PKs are set on a
       relationship with accessor single or filter
 
-0.29 Thu May 2, 2013
+0.29 2013-05-02
     - Remove DBIx::Class::InflateColumn::FS dependency
 
-0.28  Wed Apr 3, 2013
+0.28 2013-04-03
     - Don't delete and re-add all many-to-many rows. Transform m2m data to
       recursive has_many data if IntrospectableM2M is loaded.
 
-0.27  Tues Feb 26, 2013
+0.27 2013-02-26
     - Do an update on the object when there are 'other_updates' in addition
       to when the row 'is_changed' because of possible custom update methods
 
-0.26  Wed Nov 28, 2012
+0.26 2012-11-28
     - Fix multi-pk has_many bug
     - Fix has_many with where conditions
 
-0.25  Thu Apr 12, 2012
+0.25 2012-04-12
     - Suppress DBIC warnings: NULL/undef values supplied for requested
       unique constraint 'primary'.
 
-0.24      2011-05-16 15:34:10 America/New_York
+0.24 2011-05-16 15:34:10 America/New_York
     - Fixed test case that was failing on newer versions of DBIC, which
       is more strict when inspecting relationship join conditions.  You
       will need this when you want to upgrade DBIC.
 
-0.23      2011-02-24 18:23:50 Europe/Vienna
+0.23 2011-02-24 18:23:50 Europe/Vienna
     - Fixed moosified-rs.t failures by making the test skip if not all
       dependencies are met. Requiring Moose for a compatability test would
       have been overkill. (thanks CPANTesters & RT#65959)
 
-0.22      2011-02-09 19:06:34 Europe/Vienna
+0.22 2011-02-09 19:06:34 Europe/Vienna
     - Fixed updating of nullable has_many rels (RT#65561)
     - Fixed usage with moosified resultsets (RT#64773)
 
-0.21      2010-10-28 16:56:18 Europe/Vienna
+0.21 2010-10-28 16:56:18 Europe/Vienna
     - Warn instead of throwing an exception if a key is neither
       a column, a relationship nor a many-to-many helper.
     - More documentation improvements
 
-0.20      2010-10-19 09:25:33 Europe/Vienna
+0.20 2010-10-19 09:25:33 Europe/Vienna
     - Support has_many relationships with multi-column primary keys
 
-0.013  Thu Apr 08 15:37:13 UTC  2010
+0.013 2010-04-08 15:37:13 UTC
     - Allow might_have relationships to be empty
 
-0.012  Thu Sep 10 19:44:25 CEST 2009
+0.012 2009-09-10 19:44:25 CEST
     - updating records linked to by many to many
 
-0.009  Sat Jun 20 16:37:57 CEST 2009
+0.009 2009-06-20 16:37:57 CEST
     - if_not_submitted flag (experimental)
 
-0.006  Fri May 15 11:03:48 CEST 2009
+0.006 2009-05-15 11:03:48 CEST
     - Some adjustments for HTML::FormHandler
 
-0.004  Sun Apr 19 11:15:57 CEST 2009
+0.004 2009-04-19 11:15:57 CEST
     - Added functional interface - for easy use in Form Processors
 
-0.001  Wed Jun 18 13:09:28 2008
+0.001 2008-06-18 13:09:28
     - Initial release.
+


### PR DESCRIPTION
Hi Gerda,

I've reformatted your Changes file according to the spec in CPAN::Changes::Spec. This was mainly changing the dates to be in ISO 8601 date format. I also made the spacing consistent.

Following this format means that various tools can more easily process your distribution automatically.

You can find out more about this at Brian Cassidy's [CPAN::Changes Kwalitee Service](http://changes.cpanhq.org), which is where I saw your module listed :-)

Cheers,
Neil

PS I'm doing this because I'm on a quest to help improve CPAN:

> http://questhub.io/realm/perl/quest/51f0337718ba7d3959000086
