### PR TITLE
fix compatibility with 0.34 and add test code

### DIFF
--- a/t/99_m2m_form.t
+++ b/t/99_m2m_form.t
@@ -1,0 +1,56 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+use lib qw(t/lib);
+use M2MTest;
+use Module::Runtime qw(require_module);
+
+eval "use HTML::FormHandler::TraitFor::Model::DBIC";
+plan skip_all => "HTML::FormHandler::TraitFor::Model::DBIC required for testing"
+    if $@;
+
+for (1..4) {
+    my $schema_class = "M2MTest::Schema$_" ;
+    for (1..2) {
+        my $schema = M2MTest->init_schema( schema_class => $schema_class );
+        my $form_class = "M2MTest::Form::Dvd$_";
+        require_module $form_class;
+
+        lives_and {
+            my $form = $form_class->new;
+
+            my $dvd_rs = $schema->resultset('Dvd');
+            my $tag_rs = $schema->resultset('Tag');
+
+            is $dvd_rs->count, 0;
+            is $tag_rs->count, 0;
+
+            my $item = $dvd_rs->create( { name => "name1" } );
+            $item->set_tags(
+                [
+                    { name => "tag1" },
+                    { name => "tag2" },
+                    { name => "tag3" },
+                ]
+            );
+
+            is $dvd_rs->count, 1;
+            is $tag_rs->count, 3;
+            is $item->tags->count, 3;
+
+            my $params = {
+                name => "name1",
+                tags => [1,2,3],
+            };
+            $form->process( item => $item, params => $params );
+            ok $form->validated;
+
+            is $dvd_rs->count, 1;
+            is $tag_rs->count, 3;
+            is $item->tags->count, 3;
+        } "$schema_class(@{[ $schema_class->abstract ]}) $form_class(@{[ $form_class->abstract ]})";
+    }
+}
+
+done_testing();

--- a/t/99_m2m_form_compat.t
+++ b/t/99_m2m_form_compat.t
@@ -1,0 +1,56 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+use lib qw(t/lib);
+use M2MTest;
+use Module::Runtime qw(require_module);
+
+eval "use HTML::FormHandler::TraitFor::Model::DBIC";
+plan skip_all => "HTML::FormHandler::TraitFor::Model::DBIC required for testing"
+    if $@;
+
+for (4) {
+    my $schema_class = "M2MTest::Schema$_" ;
+    for (2) {
+        my $schema = M2MTest->init_schema( schema_class => $schema_class );
+        my $form_class = "M2MTest::Form::Dvd$_";
+        require_module $form_class;
+
+        lives_and {
+            my $form = $form_class->new;
+
+            my $dvd_rs = $schema->resultset('Dvd');
+            my $tag_rs = $schema->resultset('Tag');
+
+            is $dvd_rs->count, 0;
+            is $tag_rs->count, 0;
+
+            my $item = $dvd_rs->create( { name => "name1" } );
+            $item->set_tags(
+                [
+                    { name => "tag1" },
+                    { name => "tag2" },
+                    { name => "tag3" },
+                ]
+            );
+
+            is $dvd_rs->count, 1;
+            is $tag_rs->count, 3;
+            is $item->tags->count, 3;
+
+            my $params = {
+                name => "name1",
+                tags => [1,2,3],
+            };
+            $form->process( item => $item, params => $params );
+            ok $form->validated;
+
+            is $dvd_rs->count, 1;
+            is $tag_rs->count, 3;
+            is $item->tags->count, 3;
+        } "$schema_class(@{[ $schema_class->abstract ]}) $form_class(@{[ $form_class->abstract ]})";
+    }
+}
+
+done_testing();

--- a/t/99_m2m_pass.t
+++ b/t/99_m2m_pass.t
@@ -1,0 +1,59 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+use lib qw(t/lib);
+use M2MTest;
+
+for (1..4) {
+    my $schema_class = "M2MTest::Schema$_" ;
+    my $schema       = M2MTest->init_schema( schema_class => $schema_class );
+    my $rs           = $schema->resultset('Dvd');
+
+    my $item;
+    lives_and {
+        $item = DBIx::Class::ResultSet::RecursiveUpdate::Functions::recursive_update(
+            resultset => $rs,
+            updates   => {
+                name => 'name',
+                tags => [
+                    { name => 'tag1_name' },
+                ],
+            },
+        );
+        is $rs->count, 1;
+        is $rs->first->tags->count, 1;
+    } "$schema_class(@{[ $schema_class->abstract ]}) many_to_many create";
+
+    lives_and {
+        DBIx::Class::ResultSet::RecursiveUpdate::Functions::recursive_update(
+            resultset => $rs,
+            object    => $item,
+            updates   => {
+                name => 'name',
+                tags => [
+                    $item->tags->first->id,
+                ],
+            },
+        );
+        is $rs->count, 1;
+        is $rs->first->tags->count, 1;
+    } "$schema_class(@{[ $schema_class->abstract ]}) many_to_many update (tags => [ids])";
+
+    lives_and {
+        DBIx::Class::ResultSet::RecursiveUpdate::Functions::recursive_update(
+            resultset => $rs,
+            object    => $item,
+            updates   => {
+                name => 'name',
+                tags => [
+                    { id => $item->tags->first->id },
+                ],
+            },
+        );
+        is $rs->count, 1;
+        is $rs->first->tags->count, 1;
+    } "$schema_class(@{[ $schema_class->abstract ]}) many_to_many update (tags => [hashrefs])";
+}
+
+done_testing();

--- a/t/lib/M2MTest.pm
+++ b/t/lib/M2MTest.pm
@@ -1,0 +1,49 @@
+package # hide from PAUSE
+    M2MTest;
+
+use strict;
+use warnings;
+use Module::Runtime qw(require_module);
+
+sub _sqlite_dbfilename {
+    return "t/var/DBIxClass.db";
+}
+
+sub _sqlite_dbname {
+    my $self = shift;
+    my %args = @_;
+    return $self->_sqlite_dbfilename if $args{sqlite_use_file} or $ENV{"DBICTEST_SQLITE_USE_FILE"};
+	return ":memory:";
+}
+
+sub _database {
+    my $self = shift;
+    my %args = @_;
+    my $db_file = $self->_sqlite_dbname(%args);
+
+    unlink($db_file) if -e $db_file;
+    unlink($db_file . "-journal") if -e $db_file . "-journal";
+    mkdir("t/var") unless -d "t/var";
+
+    my $dsn = $ENV{"DBICTEST_DSN"} || "dbi:SQLite:${db_file}";
+    my $dbuser = $ENV{"DBICTEST_DBUSER"} || '';
+    my $dbpass = $ENV{"DBICTEST_DBPASS"} || '';
+
+    my @connect_info = ($dsn, $dbuser, $dbpass, { AutoCommit => 1 });
+
+    return @connect_info;
+}
+
+sub init_schema {
+    my $self = shift;
+    my %args = @_;
+
+    my $schema;
+    $schema = $args{schema_class} || die;
+    require_module $schema;
+    $schema = $schema->connect($self->_database(%args));
+    $schema->deploy;
+    return $schema;
+}
+
+1;

--- a/t/lib/M2MTest/Form/Dvd1.pm
+++ b/t/lib/M2MTest/Form/Dvd1.pm
@@ -1,0 +1,31 @@
+package M2MTest::Form::Dvd1;
+
+use HTML::FormHandler::Moose;
+extends 'HTML::FormHandler';
+with 'HTML::FormHandler::TraitFor::Model::DBIC';
+
+sub abstract { "HFH with DBIC containing many_to_many. tags => [ids]" }
+
+has_field name => (
+    type     => "Text",
+    required => 1,
+);
+
+has_field tags => (
+    type     => "Multiple",
+    widget   => 'CheckboxGroup',
+);
+
+# before update_model => sub {
+#     my $self = shift;
+#     use YAML::Syck;
+#     warn Dump $self->values;
+#     # ---
+#     # name: name1
+#     # tags:
+#     #   - 1
+#     #   - 2
+#     #   - 3
+# };
+
+1;

--- a/t/lib/M2MTest/Form/Dvd2.pm
+++ b/t/lib/M2MTest/Form/Dvd2.pm
@@ -1,0 +1,35 @@
+package M2MTest::Form::Dvd2;
+
+use HTML::FormHandler::Moose;
+extends 'HTML::FormHandler';
+with 'HTML::FormHandler::TraitFor::Model::DBIC';
+
+sub abstract { "HFH with DBIC containing many_to_many. tags => [hashrefs]" }
+
+has_field name => (
+    type     => "Text",
+    required => 1,
+);
+
+has_field tags => (
+    type     => "Multiple",
+    widget   => 'CheckboxGroup',
+    has_many => 'id',
+);
+
+# before update_model => sub {
+#     my $self = shift;
+#     use YAML::Syck;
+#     warn Dump $self->values;
+#     # ---
+#     # name: name1
+#     # tags: 
+#     #   -
+#     #     id: 1
+#     #   -
+#     #     id: 2
+#     #   -
+#     #     id: 3
+# };
+
+1;

--- a/t/lib/M2MTest/Schema1.pm
+++ b/t/lib/M2MTest/Schema1.pm
@@ -1,0 +1,9 @@
+package M2MTest::Schema1;
+
+use base 'DBIx::Class::Schema';
+
+sub abstract { "rel_name == pk naming" } # DBSchema::Result::Dvd like
+
+__PACKAGE__->load_namespaces( default_resultset_class => '+DBIx::Class::ResultSet::RecursiveUpdate' );
+
+1;

--- a/t/lib/M2MTest/Schema1/Result/Dvd.pm
+++ b/t/lib/M2MTest/Schema1/Result/Dvd.pm
@@ -1,0 +1,25 @@
+package M2MTest::Schema1::Result::Dvd;
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class';
+
+__PACKAGE__->load_components(qw/Core/);
+__PACKAGE__->table('dvd');
+__PACKAGE__->add_columns(
+  'dvd_id' => {
+    data_type => 'integer',
+    is_auto_increment => 1
+  },
+  'name' => {
+    data_type => 'varchar',
+    size      => 100,
+    is_nullable => 1,
+  },
+);
+__PACKAGE__->set_primary_key('dvd_id');
+__PACKAGE__->has_many('dvdtags', 'M2MTest::Schema1::Result::Dvdtag', { 'foreign.dvd' => 'self.dvd_id' });
+__PACKAGE__->many_to_many('tags', 'dvdtags' => 'tag');
+
+1;

--- a/t/lib/M2MTest/Schema1/Result/Dvdtag.pm
+++ b/t/lib/M2MTest/Schema1/Result/Dvdtag.pm
@@ -1,0 +1,19 @@
+package M2MTest::Schema1::Result::Dvdtag;
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class';
+
+__PACKAGE__->load_components("PK::Auto", "Core");
+__PACKAGE__->table("dvdtag");
+__PACKAGE__->add_columns(
+    "dvd" => { data_type => 'integer' },
+    "tag" => { data_type => 'integer' },
+);
+__PACKAGE__->set_primary_key("dvd", "tag");
+__PACKAGE__->belongs_to("dvd", "M2MTest::Schema1::Result::Dvd", { dvd_id => "dvd" });
+__PACKAGE__->belongs_to("tag", "M2MTest::Schema1::Result::Tag", { id => "tag" });
+
+1;
+

--- a/t/lib/M2MTest/Schema1/Result/Tag.pm
+++ b/t/lib/M2MTest/Schema1/Result/Tag.pm
@@ -1,0 +1,31 @@
+package M2MTest::Schema1::Result::Tag;
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class';
+
+__PACKAGE__->load_components("PK::Auto", "Core");
+__PACKAGE__->table("tag");
+__PACKAGE__->add_columns(
+  "id" => {
+    data_type => 'integer',
+    is_auto_increment => 1
+  },
+  'name' => {
+    data_type => 'varchar',
+    size      => 100,
+    is_nullable => 1,
+  },
+  'file' => {
+    data_type => 'text',
+    is_nullable => 1,
+  }
+);
+    
+__PACKAGE__->set_primary_key("id");
+__PACKAGE__->has_many("dvdtags", "M2MTest::Schema1::Result::Dvdtag", { "foreign.tag" => "self.id" });
+__PACKAGE__->many_to_many('dvds', 'dvdtags' => 'dvd');
+
+1;
+

--- a/t/lib/M2MTest/Schema2.pm
+++ b/t/lib/M2MTest/Schema2.pm
@@ -1,0 +1,9 @@
+package M2MTest::Schema2;
+
+use base 'DBIx::Class::Schema';
+
+sub abstract { "rel_name == pk naming. +IntrospectableM2M" }
+
+__PACKAGE__->load_namespaces( default_resultset_class => '+DBIx::Class::ResultSet::RecursiveUpdate' );
+
+1;

--- a/t/lib/M2MTest/Schema2/Result/Dvd.pm
+++ b/t/lib/M2MTest/Schema2/Result/Dvd.pm
@@ -1,0 +1,26 @@
+package M2MTest::Schema2::Result::Dvd;
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class';
+
+__PACKAGE__->load_components(qw/IntrospectableM2M Core/);
+__PACKAGE__->table('dvd');
+__PACKAGE__->add_columns(
+  'dvd_id' => {
+    data_type => 'integer',
+    is_auto_increment => 1
+  },
+  'name' => {
+    data_type => 'varchar',
+    size      => 100,
+    is_nullable => 1,
+  },
+);
+__PACKAGE__->set_primary_key('dvd_id');
+__PACKAGE__->has_many('dvdtags', 'M2MTest::Schema2::Result::Dvdtag', { 'foreign.dvd' => 'self.dvd_id' });
+__PACKAGE__->many_to_many('tags', 'dvdtags' => 'tag');
+
+1;
+

--- a/t/lib/M2MTest/Schema2/Result/Dvdtag.pm
+++ b/t/lib/M2MTest/Schema2/Result/Dvdtag.pm
@@ -1,0 +1,20 @@
+package M2MTest::Schema2::Result::Dvdtag;
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class';
+
+__PACKAGE__->load_components("PK::Auto", "Core");
+__PACKAGE__->table("dvdtag");
+__PACKAGE__->add_columns(
+    "dvd" => { data_type => 'integer' },
+    "tag" => { data_type => 'integer' },
+);
+__PACKAGE__->set_primary_key("dvd", "tag");
+__PACKAGE__->belongs_to("dvd", "M2MTest::Schema2::Result::Dvd", { dvd_id => "dvd" });
+__PACKAGE__->belongs_to("tag", "M2MTest::Schema2::Result::Tag", { id => "tag" });
+
+1;
+
+

--- a/t/lib/M2MTest/Schema2/Result/Tag.pm
+++ b/t/lib/M2MTest/Schema2/Result/Tag.pm
@@ -1,0 +1,31 @@
+package M2MTest::Schema2::Result::Tag;
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class';
+
+__PACKAGE__->load_components("PK::Auto", "Core");
+__PACKAGE__->table("tag");
+__PACKAGE__->add_columns(
+  "id" => {
+    data_type => 'integer',
+    is_auto_increment => 1
+  },
+  'name' => {
+    data_type => 'varchar',
+    size      => 100,
+    is_nullable => 1,
+  },
+  'file' => {
+    data_type => 'text',
+    is_nullable => 1,
+  }
+);
+    
+__PACKAGE__->set_primary_key("id");
+__PACKAGE__->has_many("dvdtags", "M2MTest::Schema2::Result::Dvdtag", { "foreign.tag" => "self.id" });
+__PACKAGE__->many_to_many('dvds', 'dvdtags' => 'dvd');
+
+1;
+

--- a/t/lib/M2MTest/Schema3.pm
+++ b/t/lib/M2MTest/Schema3.pm
@@ -1,0 +1,9 @@
+package M2MTest::Schema3;
+
+use base 'DBIx::Class::Schema';
+
+sub abstract { "rel_name != pk naming" }
+
+__PACKAGE__->load_namespaces( default_resultset_class => '+DBIx::Class::ResultSet::RecursiveUpdate' );
+
+1;

--- a/t/lib/M2MTest/Schema3/Result/Dvd.pm
+++ b/t/lib/M2MTest/Schema3/Result/Dvd.pm
@@ -1,0 +1,25 @@
+package M2MTest::Schema3::Result::Dvd;
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class';
+
+__PACKAGE__->load_components(qw/Core/);
+__PACKAGE__->table('dvd');
+__PACKAGE__->add_columns(
+  'id' => {
+    data_type => 'integer',
+    is_auto_increment => 1
+  },
+  'name' => {
+    data_type => 'varchar',
+    size      => 100,
+    is_nullable => 1,
+  },
+);
+__PACKAGE__->set_primary_key('id');
+__PACKAGE__->has_many('dvd_tags', 'M2MTest::Schema3::Result::DvdTag', { 'foreign.dvd_id' => 'self.id' });
+__PACKAGE__->many_to_many('tags', 'dvd_tags' => 'tag');
+
+1;

--- a/t/lib/M2MTest/Schema3/Result/DvdTag.pm
+++ b/t/lib/M2MTest/Schema3/Result/DvdTag.pm
@@ -1,0 +1,20 @@
+package M2MTest::Schema3::Result::DvdTag;
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class';
+
+__PACKAGE__->load_components("PK::Auto", "Core");
+__PACKAGE__->table("dvd_tag");
+__PACKAGE__->add_columns(
+    "dvd_id" => { data_type => 'integer' },
+    "tag_id" => { data_type => 'integer' },
+);
+__PACKAGE__->set_primary_key("dvd_id", "tag_id");
+__PACKAGE__->belongs_to("dvd", "M2MTest::Schema3::Result::Dvd", { id => "dvd_id" });
+__PACKAGE__->belongs_to("tag", "M2MTest::Schema3::Result::Tag", { id => "tag_id" });
+
+1;
+
+

--- a/t/lib/M2MTest/Schema3/Result/Tag.pm
+++ b/t/lib/M2MTest/Schema3/Result/Tag.pm
@@ -1,0 +1,30 @@
+package M2MTest::Schema3::Result::Tag;
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class';
+
+__PACKAGE__->load_components("PK::Auto", "Core");
+__PACKAGE__->table("tag");
+__PACKAGE__->add_columns(
+  "id" => {
+    data_type => 'integer',
+    is_auto_increment => 1
+  },
+  'name' => {
+    data_type => 'varchar',
+    size      => 100,
+    is_nullable => 1,
+  },
+  'file' => {
+    data_type => 'text',
+    is_nullable => 1,
+  }
+);
+    
+__PACKAGE__->set_primary_key("id");
+__PACKAGE__->has_many("dvd_tags", "M2MTest::Schema3::Result::DvdTag", { "foreign.tag_id" => "self.id" });
+__PACKAGE__->many_to_many('dvds', 'dvd_tags' => 'dvd');
+
+1;

--- a/t/lib/M2MTest/Schema4.pm
+++ b/t/lib/M2MTest/Schema4.pm
@@ -1,0 +1,9 @@
+package M2MTest::Schema4;
+
+use base 'DBIx::Class::Schema';
+
+sub abstract { "rel_name != pk naming. +IntrospectableM2M" }
+
+__PACKAGE__->load_namespaces( default_resultset_class => '+DBIx::Class::ResultSet::RecursiveUpdate' );
+
+1;

--- a/t/lib/M2MTest/Schema4/Result/Dvd.pm
+++ b/t/lib/M2MTest/Schema4/Result/Dvd.pm
@@ -1,0 +1,26 @@
+package M2MTest::Schema4::Result::Dvd;
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class';
+
+__PACKAGE__->load_components(qw/IntrospectableM2M Core/);
+__PACKAGE__->table('dvd');
+__PACKAGE__->add_columns(
+  'id' => {
+    data_type => 'integer',
+    is_auto_increment => 1
+  },
+  'name' => {
+    data_type => 'varchar',
+    size      => 100,
+    is_nullable => 1,
+  },
+);
+__PACKAGE__->set_primary_key('id');
+__PACKAGE__->has_many('dvd_tags', 'M2MTest::Schema4::Result::DvdTag', { 'foreign.dvd_id' => 'self.id' });
+__PACKAGE__->many_to_many('tags', 'dvd_tags' => 'tag');
+
+1;
+

--- a/t/lib/M2MTest/Schema4/Result/DvdTag.pm
+++ b/t/lib/M2MTest/Schema4/Result/DvdTag.pm
@@ -1,0 +1,20 @@
+package M2MTest::Schema4::Result::DvdTag;
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class';
+
+__PACKAGE__->load_components("PK::Auto", "Core");
+__PACKAGE__->table("dvd_tag");
+__PACKAGE__->add_columns(
+    "dvd_id" => { data_type => 'integer' },
+    "tag_id" => { data_type => 'integer' },
+);
+__PACKAGE__->set_primary_key("dvd_id", "tag_id");
+__PACKAGE__->belongs_to("dvd", "M2MTest::Schema4::Result::Dvd", { id => "dvd_id" });
+__PACKAGE__->belongs_to("tag", "M2MTest::Schema4::Result::Tag", { id => "tag_id" });
+
+1;
+
+

--- a/t/lib/M2MTest/Schema4/Result/Tag.pm
+++ b/t/lib/M2MTest/Schema4/Result/Tag.pm
@@ -1,0 +1,30 @@
+package M2MTest::Schema4::Result::Tag;
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class';
+
+__PACKAGE__->load_components("PK::Auto", "Core");
+__PACKAGE__->table("tag");
+__PACKAGE__->add_columns(
+  "id" => {
+    data_type => 'integer',
+    is_auto_increment => 1
+  },
+  'name' => {
+    data_type => 'varchar',
+    size      => 100,
+    is_nullable => 1,
+  },
+  'file' => {
+    data_type => 'text',
+    is_nullable => 1,
+  }
+);
+    
+__PACKAGE__->set_primary_key("id");
+__PACKAGE__->has_many("dvd_tags", "M2MTest::Schema4::Result::DvdTag", { "foreign.tag_id" => "self.id" });
+__PACKAGE__->many_to_many('dvds', 'dvd_tags' => 'dvd');
+
+1;


### PR DESCRIPTION
Hello.

## 1. Incompatibility

I recently upgraded to 0.40 and my existing code is no longer working.

It's a form containing a simple many_to_many using HTML::FormHandler::Model::DBIC.

I wrote test code in [t/99_m2m_form_compat.t](https://github.com/gshank/dbix-class-resultset-recursiveupdate/compare/master...bokutin:lost_compat_0.34?expand=1#diff-189e94a7f548dd2161e2149c6d14ae7a) that reproduces the problem.

% curl -so - https://cpan.metacpan.org/modules/by-module/DBIx/DBIx-Class-ResultSet-RecursiveUpdate-0.34.tar.gz | tar xzf -
% curl -so - https://cpan.metacpan.org/modules/by-module/DBIx/DBIx-Class-ResultSet-RecursiveUpdate-0.40.tar.gz | tar xzf -
% curl -so - https://cpan.metacpan.org/modules/by-module/DBIx/DBIx-Class-ResultSet-RecursiveUpdate-0.41.tar.gz | tar xzf -

% prove -I DBIx-Class-ResultSet-RecursiveUpdate-0.34/lib t/99_m2m_form_compat.t
pass
% prove -I DBIx-Class-ResultSet-RecursiveUpdate-0.40/lib t/99_m2m_form_compat.t
fail
% prove -I DBIx-Class-ResultSet-RecursiveUpdate-0.41/lib t/99_m2m_form_compat.t
fail
% prove -I lib t/99_m2m_form_compat.t (This pull request has been applied)
pass



## 2. Cause of the problem

For [set_$rel](https://github.com/gshank/dbix-class-resultset-recursiveupdate/blob/fe1bbbc28a2daa3e00d5abbfe1d948c8c249d500/lib/DBIx/Class/ResultSet/RecursiveUpdate.pm#L251) it works fine.
For [IntrospectableM2M](https://github.com/gshank/dbix-class-resultset-recursiveupdate/blob/fe1bbbc28a2daa3e00d5abbfe1d948c8c249d500/lib/DBIx/Class/ResultSet/RecursiveUpdate.pm#L240) it does not work.

For the latter, the problem is the implicit assumption that the relation name and pk are the [same](https://github.com/gshank/dbix-class-resultset-recursiveupdate/blob/fe1bbbc28a2daa3e00d5abbfe1d948c8c249d500/t/lib/DBSchema/Result/Dvdtag.pm#L18).
[Not the same naming](https://github.com/bokutin/dbix-class-resultset-recursiveupdate/blob/4e27728d4f2d85c9fd779df0d200e70bccb37857/t/lib/M2MTest/Schema3/Result/DvdTag.pm#L16) also let's assume.



## 3. differences between set_$rel and IntrospectableM2M

There are cases where it works with set_$rel but not IntrospectableM2M.

It's in the current 0.41 and it's also in 0.34 and earlier.

I added test code to t/99_m2m_form.t and t/99_m2m_pass.t so that we can test it in the common case.

I think this test needs to pass.


---

My changes may not be good code to be merged as-is, but I hope they reveal the problem.

Since 0.40, I think the reduction of aggressive select queries is very nice!

Thanks.
