### PR TITLE
use List::Util instead of List::MoreUtils for `any`, `all` and `none`

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -4,7 +4,7 @@ requires 'DBIx::Class::IntrospectableM2M';
 requires 'SQL::Translator' => 0.11016;
 requires 'DateTime';
 requires 'DBD::SQLite' => 1.21;
-requires 'List::Util' => 1.33;
+requires 'List::Util' => 1.35;
 requires 'Carp::Clan' => 6.04;
 requires 'Data::Dumper::Concise' => 2.020;
 requires 'Try::Tiny' => 0.30;

--- a/cpanfile
+++ b/cpanfile
@@ -4,7 +4,7 @@ requires 'DBIx::Class::IntrospectableM2M';
 requires 'SQL::Translator' => 0.11016;
 requires 'DateTime';
 requires 'DBD::SQLite' => 1.21;
-requires 'List::MoreUtils' => 0.22;
+requires 'List::Util' => 1.33;
 requires 'Carp::Clan' => 6.04;
 requires 'Data::Dumper::Concise' => 2.020;
 requires 'Try::Tiny' => 0.30;

--- a/lib/DBIx/Class/ResultSet/RecursiveUpdate.pm
+++ b/lib/DBIx/Class/ResultSet/RecursiveUpdate.pm
@@ -40,7 +40,7 @@ package DBIx::Class::ResultSet::RecursiveUpdate::Functions;
 use v5.14; # for non-destructive substitution regex modifier
 use Carp::Clan qw/^DBIx::Class|^HTML::FormHandler|^Try::Tiny/;
 use Scalar::Util qw( blessed );
-use List::MoreUtils qw/ any all none /;
+use List::Util qw/ any all none /;
 use Try::Tiny;
 use Data::Dumper::Concise;
 


### PR DESCRIPTION
Suggestion: use  `List::Util` instead of `List::MoreUtils` for these functions.  They are all available as of version 1.33, and `List::Util` is bundled with Perl, so reduces the number of dependencies on newer Perls.